### PR TITLE
Fixed for React 15.2.0+

### DIFF
--- a/src/ReactTransitionGroupPlus.js
+++ b/src/ReactTransitionGroupPlus.js
@@ -320,6 +320,14 @@ var ReactTransitionGroupPlus = React.createClass({
     }
   },
 
+  cleanProps: function(props) {
+    delete props.component;
+    delete props.transitionMode;
+    delete props.childFactory;
+    delete props.deferLeavingComponentRemoval;
+    return props;
+  },
+
   render: function() {
     // TODO: we could get rid of the need for the wrapper node
     // by cloning a single child
@@ -340,7 +348,7 @@ var ReactTransitionGroupPlus = React.createClass({
     }
     return React.createElement(
       this.props.component,
-      this.props,
+      this.cleanProps(assign({},this.props)),
       childrenToRender
     );
   },


### PR DESCRIPTION
Fixes this error in React 15.2.0

```
Warning: Unknown props `component`, `transitionMode`, `childFactory`, `deferLeavingComponentRemoval` on <div> tag. Remove these props from the element. For details, see https://fb.me/react-unknown-prop
```

I wasn't sure if modifying the props object directly was advisable, so i clone the object first.
