### PR TITLE
fix for undefined component in _handleDoneEntering

### DIFF
--- a/src/ReactTransitionGroupPlus.js
+++ b/src/ReactTransitionGroupPlus.js
@@ -212,7 +212,7 @@ var ReactTransitionGroupPlus = React.createClass({
     this.deferredLeaveRemovalCallbacks = [];
 
     var component = this.refs[key];
-    if (component.componentDidEnter) {
+    if (component && component.componentDidEnter) {
       component.componentDidEnter();
     }
 


### PR DESCRIPTION
This checks for the existence of `component` before continuing with the work in `_handleDoneEntering` to avoid uncaught errors described in #12 

