### PR TITLE
Catches when component is undefined.

### DIFF
--- a/src/ReactTransitionGroupPlus.js
+++ b/src/ReactTransitionGroupPlus.js
@@ -155,7 +155,7 @@ var ReactTransitionGroupPlus = React.createClass({
 
   _handleDoneAppearing: function(key) {
     var component = this.refs[key];
-    if (component.componentDidAppear) {
+    if (component && component.componentDidAppear) {
       component.componentDidAppear();
     }
 


### PR DESCRIPTION
I've noticed that sometime when a Transition group processes really fast sometimes component is undefined. This is to fix that error.